### PR TITLE
change the super user id to 1, which is what currently is used

### DIFF
--- a/leaderBoard.php
+++ b/leaderBoard.php
@@ -89,7 +89,7 @@ include_once ("include/leaderBoardHeader.php");
                     $MAP=$row_eval[4];
                     $P30=$row_eval[5];
 
-                    if($uid == 0){
+                    if($uid == 1){
                         // super user, do not have user name.
                         continue;
                     }

--- a/leaderBoardPer.php
+++ b/leaderBoardPer.php
@@ -91,7 +91,7 @@ include_once ("include/leaderBoardHeader.php");
                     $MAP=$row_eval[4];
                     $P30=$row_eval[5];
 
-                    if($uid == 0){
+                    if($uid == 1){
                         // super user, do not have user name.
                         continue;
                     }


### PR DESCRIPTION
Change the super user id to 1, which is what currently is in use. This will result in omitting the retrieval functions of super user on the leader board.